### PR TITLE
replace default_supp_shape_from_params with supp_shape_from_ref_param…

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -32,8 +32,11 @@ from pytensor.sparse.basic import sp_sum
 from pytensor.tensor import TensorConstant, gammaln, sigmoid
 from pytensor.tensor.nlinalg import det, eigh, matrix_inverse, trace
 from pytensor.tensor.random.basic import dirichlet, multinomial, multivariate_normal
-from pytensor.tensor.random.op import RandomVariable, default_supp_shape_from_params
-from pytensor.tensor.random.utils import broadcast_params
+from pytensor.tensor.random.op import RandomVariable
+from pytensor.tensor.random.utils import (
+    broadcast_params,
+    supp_shape_from_ref_param_shape,
+)
 from pytensor.tensor.slinalg import Cholesky, SolveTriangular
 from pytensor.tensor.type import TensorType
 from scipy import linalg, stats
@@ -321,8 +324,11 @@ class MvStudentTRV(RandomVariable):
         return super().__call__(nu, mu, cov, size=size, **kwargs)
 
     def _supp_shape_from_params(self, dist_params, rep_param_idx=1, param_shapes=None):
-        return default_supp_shape_from_params(
-            self.ndim_supp, dist_params, rep_param_idx, param_shapes
+        return supp_shape_from_ref_param_shape(
+            ndim_supp=self.ndim_supp,
+            dist_params=dist_params,
+            param_shapes=param_shapes,
+            ref_param_idx=rep_param_idx,
         )
 
     @classmethod
@@ -612,8 +618,11 @@ class DirichletMultinomialRV(RandomVariable):
     _print_name = ("DirichletMN", "\\operatorname{DirichletMN}")
 
     def _supp_shape_from_params(self, dist_params, rep_param_idx=1, param_shapes=None):
-        return default_supp_shape_from_params(
-            self.ndim_supp, dist_params, rep_param_idx, param_shapes
+        return supp_shape_from_ref_param_shape(
+            ndim_supp=self.ndim_supp,
+            dist_params=dist_params,
+            param_shapes=param_shapes,
+            ref_param_idx=rep_param_idx,
         )
 
     @classmethod


### PR DESCRIPTION
**What is this PR about?**

For compatibility with latest PyTensor release.  Replaces `default_supp_shape_from_params`, which was removed, with `supp_shape_from_ref_param_shape`.






<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--3.org.readthedocs.build/en/3/

<!-- readthedocs-preview pymc end -->