### PR TITLE
Keep deprecation warnings for ArviZ aliases

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -46,36 +46,19 @@ def __set_compiler_flags():
 
 __set_compiler_flags()
 
-from pymc import _version, gp, ode, sampling
-from pymc.backends import *
-from pymc.blocking import *
+from pymc import _version, gp, ode, plots, sampling, stats
 from pymc.data import *
 from pymc.distributions import *
-from pymc.exceptions import *
 from pymc.func_utils import find_constrained_prior
 from pymc.logprob import *
-from pymc.math import (
-    expand_packed_triangular,
-    invlogit,
-    invprobit,
-    logaddexp,
-    logit,
-    logsumexp,
-    probit,
-)
 from pymc.model.core import *
 from pymc.model.transform.conditioning import do, observe
 from pymc.model_graph import model_to_graphviz, model_to_networkx
-from pymc.plots import *
-from pymc.printing import *
 from pymc.pytensorf import *
 from pymc.sampling import *
 from pymc.smc import *
-from pymc.stats import *
 from pymc.step_methods import *
 from pymc.tuning import *
-from pymc.util import drop_warning_stat
 from pymc.variational import *
-from pymc.vartypes import *
 
 __version__ = _version.get_versions()["version"]

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -54,6 +54,7 @@ from pymc.logprob import *
 from pymc.model.core import *
 from pymc.model.transform.conditioning import do, observe
 from pymc.model_graph import model_to_graphviz, model_to_networkx
+from pymc.plots import DEPRECATED_PLOTS_ALIASES
 from pymc.pytensorf import *
 from pymc.sampling import *
 from pymc.smc import *
@@ -62,3 +63,14 @@ from pymc.tuning import *
 from pymc.variational import *
 
 __version__ = _version.get_versions()["version"]
+
+
+def __getattr__(name):
+    if name in DEPRECATED_PLOTS_ALIASES:
+        new_name = DEPRECATED_PLOTS_ALIASES[name]
+        raise ImportError(
+            f"The function `{name}` from PyMC was an alias for `{new_name}` from "
+            f"ArviZ. It was removed in PyMC 4.0. "
+            f"Switch to `pymc.{new_name}` or `arviz.{new_name}`."
+        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -45,10 +45,6 @@ from pymc.util import get_var_name
 logger = logging.getLogger(__name__)
 
 
-class BackendError(Exception):
-    pass
-
-
 class IBaseTrace(ABC, Sized):
     """Minimal interface needed to record and access draws and stats for one MCMC chain."""
 

--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -37,9 +37,6 @@ import numpy as np
 
 from typing_extensions import TypeAlias
 
-__all__ = ["DictToArrayBijection"]
-
-
 T = TypeVar("T")
 PointType: TypeAlias = Dict[str, np.ndarray]
 StatsDict: TypeAlias = Dict[str, Any]

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -40,7 +40,6 @@ from pymc.pytensorf import convert_observed_data
 
 __all__ = [
     "get_data",
-    "GeneratorAdapter",
     "Minibatch",
     "Data",
     "ConstantData",

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -36,6 +36,7 @@ from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 import pymc as pm
 
+from pymc.exceptions import ShapeError
 from pymc.pytensorf import convert_observed_data
 
 __all__ = [
@@ -237,7 +238,7 @@ def determine_coords(
 
     if isinstance(value, np.ndarray) and dims is not None:
         if len(dims) != value.ndim:
-            raise pm.exceptions.ShapeError(
+            raise ShapeError(
                 "Invalid data shape. The rank of the dataset must match the " "length of `dims`.",
                 actual=value.shape,
                 expected=value.ndim,
@@ -445,7 +446,7 @@ def Data(
     if isinstance(dims, str):
         dims = (dims,)
     if not (dims is None or len(dims) == x.ndim):
-        raise pm.exceptions.ShapeError(
+        raise ShapeError(
             "Length of `dims` must match the dimensions of the dataset.",
             actual=len(dims),
             expected=x.ndim,

--- a/pymc/exceptions.py
+++ b/pymc/exceptions.py
@@ -12,13 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-__all__ = [
-    "SamplingError",
-    "ImputationWarning",
-    "ShapeWarning",
-    "ShapeError",
-]
-
 
 class SamplingError(RuntimeError):
     pass
@@ -74,3 +67,55 @@ class NotConstantValueError(ValueError):
 
 class BlockModelAccessError(RuntimeError):
     pass
+
+
+class ParallelSamplingError(Exception):
+    def __init__(self, message, chain):
+        super().__init__(message)
+        self._chain = chain
+
+
+class RemoteTraceback(Exception):
+    def __init__(self, tb):
+        self.tb = tb
+
+    def __str__(self):
+        return self.tb
+
+
+class VariationalInferenceError(Exception):
+    """Exception for VI specific cases"""
+
+
+class NotImplementedInference(VariationalInferenceError, NotImplementedError):
+    """Marking non functional parts of code"""
+
+
+class ExplicitInferenceError(VariationalInferenceError, TypeError):
+    """Exception for bad explicit inference"""
+
+
+class ParametrizationError(VariationalInferenceError, ValueError):
+    """Error raised in case of bad parametrization"""
+
+
+class GroupError(VariationalInferenceError, TypeError):
+    """Error related to VI groups"""
+
+
+class IntegrationError(RuntimeError):
+    pass
+
+
+class PositiveDefiniteError(ValueError):
+    def __init__(self, msg, idx):
+        super().__init__(msg)
+        self.idx = idx
+        self.msg = msg
+
+    def __str__(self):
+        return f"Scaling is not positive definite: {self.msg}. Check indexes {self.idx}."
+
+
+class ParameterValueError(ValueError):
+    """Exception for invalid parameters values in logprob graphs"""

--- a/pymc/exceptions.py
+++ b/pymc/exceptions.py
@@ -14,8 +14,6 @@
 
 __all__ = [
     "SamplingError",
-    "IncorrectArgumentsError",
-    "TraceDirectoryError",
     "ImputationWarning",
     "ShapeWarning",
     "ShapeError",
@@ -23,16 +21,6 @@ __all__ = [
 
 
 class SamplingError(RuntimeError):
-    pass
-
-
-class IncorrectArgumentsError(ValueError):
-    pass
-
-
-class TraceDirectoryError(ValueError):
-    """Error from trying to load a trace from an incorrectly-structured directory,"""
-
     pass
 
 

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -63,6 +63,7 @@ from pytensor.raise_op import CheckAndRaise
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.variable import TensorVariable
 
+from pymc.exceptions import ParameterValueError
 from pymc.logprob.abstract import MeasurableVariable, _logprob
 from pymc.util import makeiter
 
@@ -229,10 +230,6 @@ def check_potential_measurability(
     ):
         return True
     return False
-
-
-class ParameterValueError(ValueError):
-    """Exception for invalid parameters values in logprob graphs"""
 
 
 class CheckParameterValue(CheckAndRaise):

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -59,13 +59,13 @@ from pymc.distributions.transforms import _default_transform
 from pymc.exceptions import (
     BlockModelAccessError,
     ImputationWarning,
+    ParameterValueError,
     SamplingError,
     ShapeError,
     ShapeWarning,
 )
 from pymc.initial_point import make_initial_point_fn
 from pymc.logprob.basic import transformed_conditional_logp
-from pymc.logprob.utils import ParameterValueError
 from pymc.model_graph import model_to_graphviz
 from pymc.pytensorf import (
     PointFunc,

--- a/pymc/plots/__init__.py
+++ b/pymc/plots/__init__.py
@@ -20,7 +20,6 @@ See https://arviz-devs.github.io/arviz/ for details on plots.
 """
 import functools
 import sys
-import warnings
 
 import arviz as az
 
@@ -29,40 +28,3 @@ for attr in az.plots.__all__:
     obj = getattr(az.plots, attr)
     if not attr.startswith("__"):
         setattr(sys.modules[__name__], attr, obj)
-
-
-def alias_deprecation(func, alias: str):
-    original = func.__name__
-
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        raise FutureWarning(
-            f"The function `{alias}` from PyMC was an alias for `{original}` from ArviZ. "
-            "It was removed in PyMC 4.0. "
-            f"Switch to `pymc.{original}` or `arviz.{original}`."
-        )
-
-    return wrapped
-
-
-# Aliases of ArviZ functions
-autocorrplot = alias_deprecation(az.plot_autocorr, alias="autocorrplot")
-forestplot = alias_deprecation(az.plot_forest, alias="forestplot")
-kdeplot = alias_deprecation(az.plot_kde, alias="kdeplot")
-energyplot = alias_deprecation(az.plot_energy, alias="energyplot")
-densityplot = alias_deprecation(az.plot_density, alias="densityplot")
-pairplot = alias_deprecation(az.plot_pair, alias="pairplot")
-traceplot = alias_deprecation(az.plot_trace, alias="traceplot")
-compareplot = alias_deprecation(az.plot_compare, alias="compareplot")
-
-
-__all__ = tuple(az.plots.__all__) + (
-    "autocorrplot",
-    "compareplot",
-    "forestplot",
-    "kdeplot",
-    "traceplot",
-    "energyplot",
-    "densityplot",
-    "pairplot",
-)

--- a/pymc/plots/__init__.py
+++ b/pymc/plots/__init__.py
@@ -28,3 +28,25 @@ for attr in az.plots.__all__:
     obj = getattr(az.plots, attr)
     if not attr.startswith("__"):
         setattr(sys.modules[__name__], attr, obj)
+
+DEPRECATED_PLOTS_ALIASES = dict(
+    autocorrplot="plot_autocorr",
+    forestplot="plot_forest",
+    kdeplot="plot_kde",
+    energyplot="plot_energy",
+    densityplot="plot_density",
+    pairplot="plot_pair",
+    traceplot="plot_trace",
+    compareplot="plot_compare",
+)
+
+
+def __getattr__(name):
+    if name in DEPRECATED_PLOTS_ALIASES:
+        new_name = DEPRECATED_PLOTS_ALIASES[name]
+        raise ImportError(
+            f"The function `{name}` from PyMC was an alias for `{new_name}` from "
+            f"ArviZ. It was removed in PyMC 4.0. "
+            f"Switch to `pymc.{new_name}` or `arviz.{new_name}`."
+        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -76,16 +76,9 @@ __all__ = [
     "hessian",
     "hessian_diag",
     "inputvars",
-    "cont_inputs",
     "floatX",
     "intX",
-    "smartfloatX",
     "jacobian",
-    "CallableTensor",
-    "join_nonshared_inputs",
-    "make_shared_replacements",
-    "generator",
-    "convert_observed_data",
     "compile_pymc",
 ]
 

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -53,9 +53,11 @@ from pytensor.tensor.random.var import (
 from pytensor.tensor.sharedvar import SharedVariable
 from typing_extensions import TypeAlias
 
-import pymc as pm
-
-from pymc.backends.arviz import _DefaultTrace
+from pymc.backends.arviz import (
+    _DefaultTrace,
+    predictions_to_inference_data,
+    to_inference_data,
+)
 from pymc.backends.base import MultiTrace
 from pymc.blocking import PointType
 from pymc.model import Model, modelcontext
@@ -438,7 +440,7 @@ def sample_prior_predictive(
     ikwargs: Dict[str, Any] = dict(model=model)
     if idata_kwargs:
         ikwargs.update(idata_kwargs)
-    return pm.to_inference_data(prior=prior, **ikwargs)
+    return to_inference_data(prior=prior, **ikwargs)
 
 
 def sample_posterior_predictive(
@@ -669,8 +671,8 @@ def sample_posterior_predictive(
         if extend_inferencedata:
             ikwargs.setdefault("idata_orig", idata)
             ikwargs.setdefault("inplace", True)
-        return pm.predictions_to_inference_data(ppc_trace, **ikwargs)
-    idata_pp = pm.to_inference_data(posterior_predictive=ppc_trace, **ikwargs)
+        return predictions_to_inference_data(ppc_trace, **ikwargs)
+    idata_pp = to_inference_data(posterior_predictive=ppc_trace, **ikwargs)
 
     if extend_inferencedata and idata is not None:
         idata.extend(idata_pp)

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -52,6 +52,7 @@ from pymc.backends.arviz import (
     coords_and_dims_for_inferencedata,
     find_constants,
     find_observations,
+    to_inference_data,
 )
 from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains
 from pymc.blocking import DictToArrayBijection
@@ -892,7 +893,7 @@ def _sample_return(
     if compute_convergence_checks or return_inferencedata:
         ikwargs: Dict[str, Any] = dict(model=model, save_warmup=not discard_tuned_samples)
         ikwargs.update(idata_kwargs)
-        idata = pm.to_inference_data(mtrace, **ikwargs)
+        idata = to_inference_data(mtrace, **ikwargs)
 
         if compute_convergence_checks:
             warns = run_convergence_checks(idata, model)

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -56,7 +56,7 @@ from pymc.backends.arviz import (
 )
 from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains
 from pymc.blocking import DictToArrayBijection
-from pymc.exceptions import SamplingError
+from pymc.exceptions import ParallelSamplingError, SamplingError
 from pymc.initial_point import PointType, StartDict, make_initial_point_fns_per_chain
 from pymc.model import Model, modelcontext
 from pymc.sampling.parallel import Draw, _cpu_count
@@ -1199,7 +1199,7 @@ def _mp_sample(
                     if callback is not None:
                         callback(trace=strace, draw=draw)
 
-        except ps.ParallelSamplingError as error:
+        except ParallelSamplingError as error:
             strace = traces[error._chain]
             for strace in traces:
                 strace.close()

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -29,25 +29,13 @@ import numpy as np
 from fastprogress.fastprogress import progress_bar
 
 from pymc.blocking import DictToArrayBijection
-from pymc.exceptions import SamplingError
+from pymc.exceptions import ParallelSamplingError, RemoteTraceback, SamplingError
 from pymc.util import RandomSeed
 
 logger = logging.getLogger(__name__)
 
 
-class ParallelSamplingError(Exception):
-    def __init__(self, message, chain):
-        super().__init__(message)
-        self._chain = chain
-
-
 # Taken from https://hg.python.org/cpython/rev/c4f92b597074
-class RemoteTraceback(Exception):
-    def __init__(self, tb):
-        self.tb = tb
-
-    def __str__(self):
-        return self.tb
 
 
 class ExceptionWithTraceback:

--- a/pymc/stats/__init__.py
+++ b/pymc/stats/__init__.py
@@ -28,5 +28,3 @@ for attr in az.stats.__all__:
         setattr(sys.modules[__name__], attr, obj)
 
 from pymc.stats.log_likelihood import compute_log_likelihood
-
-__all__ = ("compute_log_likelihood",) + tuple(az.stats.__all__)

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -23,14 +23,14 @@ from typing import Any, NamedTuple
 import numpy as np
 
 from pymc.blocking import DictToArrayBijection, RaveledVars, StatsType
-from pymc.exceptions import SamplingError
+from pymc.exceptions import IntegrationError, SamplingError
 from pymc.model import Point, modelcontext
 from pymc.pytensorf import floatX
 from pymc.stats.convergence import SamplerWarning, WarningType
 from pymc.step_methods import step_sizes
 from pymc.step_methods.arraystep import GradientSharedStep
 from pymc.step_methods.hmc import integration
-from pymc.step_methods.hmc.integration import IntegrationError, State
+from pymc.step_methods.hmc.integration import State
 from pymc.step_methods.hmc.quadpotential import QuadPotentialDiagAdapt, quad_potential
 from pymc.tuning import guess_scaling
 from pymc.util import get_value_vars_from_user_vars

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -18,10 +18,11 @@ from typing import Any
 
 import numpy as np
 
+from pymc.exceptions import IntegrationError
 from pymc.stats.convergence import SamplerWarning
 from pymc.step_methods.compound import Competence
 from pymc.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
-from pymc.step_methods.hmc.integration import IntegrationError, State
+from pymc.step_methods.hmc.integration import State
 from pymc.vartypes import discrete_types
 
 __all__ = ["HamiltonianMC"]

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -19,6 +19,7 @@ import numpy as np
 from scipy import linalg
 
 from pymc.blocking import RaveledVars
+from pymc.exceptions import IntegrationError
 from pymc.step_methods.hmc.quadpotential import QuadPotential
 
 
@@ -30,10 +31,6 @@ class State(NamedTuple):
     energy: float
     model_logp: float
     index_in_trajectory: int
-
-
-class IntegrationError(RuntimeError):
-    pass
 
 
 class CpuLeapfrogIntegrator:

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -18,13 +18,14 @@ from collections import namedtuple
 
 import numpy as np
 
+from pymc.exceptions import IntegrationError
 from pymc.math import logbern
 from pymc.pytensorf import floatX
 from pymc.stats.convergence import SamplerWarning
 from pymc.step_methods.compound import Competence
 from pymc.step_methods.hmc import integration
 from pymc.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
-from pymc.step_methods.hmc.integration import IntegrationError, State
+from pymc.step_methods.hmc.integration import State
 from pymc.vartypes import continuous_types
 
 __all__ = ["NUTS"]

--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -25,6 +25,7 @@ import scipy.linalg
 from numpy.random import normal
 from scipy.sparse import issparse
 
+from pymc.exceptions import PositiveDefiniteError
 from pymc.pytensorf import floatX
 
 __all__ = [
@@ -85,16 +86,6 @@ def partial_check_positive_definite(C):
 
     if len(i):
         raise PositiveDefiniteError("Simple check failed. Diagonal contains negatives", i)
-
-
-class PositiveDefiniteError(ValueError):
-    def __init__(self, msg, idx):
-        super().__init__(msg)
-        self.idx = idx
-        self.msg = msg
-
-    def __str__(self):
-        return f"Scaling is not positive definite: {self.msg}. Check indexes {self.idx}."
 
 
 class QuadPotential:

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -31,6 +31,7 @@ from pymc.pytensorf import (
     compile_pymc,
     floatX,
     join_nonshared_inputs,
+    make_shared_replacements,
     replace_rng_nodes,
 )
 from pymc.step_methods.arraystep import (
@@ -804,7 +805,7 @@ class DEMetropolis(PopulationArrayStepShared):
 
         self.mode = mode
 
-        shared = pm.make_shared_replacements(initial_values, vars, model)
+        shared = make_shared_replacements(initial_values, vars, model)
         self.delta_logp = delta_logp(initial_values, model.logp(), vars, shared)
         super().__init__(vars, shared)
 
@@ -960,7 +961,7 @@ class DEMetropolisZ(ArrayStepShared):
 
         self.mode = mode
 
-        shared = pm.make_shared_replacements(initial_values, vars, model)
+        shared = make_shared_replacements(initial_values, vars, model)
         self.delta_logp = delta_logp(initial_values, model.logp(), vars, shared)
         super().__init__(vars, shared)
 

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -34,9 +34,10 @@ import pymc as pm
 
 from pymc.distributions.distribution import Distribution
 from pymc.distributions.shape_utils import change_dist_size
+from pymc.exceptions import ParameterValueError
 from pymc.initial_point import make_initial_point_fn
 from pymc.logprob.basic import icdf, logcdf, logp, transformed_conditional_logp
-from pymc.logprob.utils import ParameterValueError, find_rvs_in_graph
+from pymc.logprob.utils import find_rvs_in_graph
 from pymc.pytensorf import (
     compile_pymc,
     floatX,

--- a/pymc/tuning/__init__.py
+++ b/pymc/tuning/__init__.py
@@ -14,3 +14,5 @@
 
 from pymc.tuning.scaling import find_hessian, guess_scaling, trace_cov
 from pymc.tuning.starting import find_MAP
+
+__all__ = ("find_MAP", "find_hessian")

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -26,12 +26,11 @@ import pymc as pm
 
 from pymc.blocking import DictToArrayBijection
 from pymc.distributions.dist_math import rho2sigma
+from pymc.exceptions import NotImplementedInference
 from pymc.util import makeiter
-from pymc.variational import opvi
 from pymc.variational.opvi import (
     Approximation,
     Group,
-    NotImplementedInference,
     _known_scan_ignored_inputs,
     node_property,
 )
@@ -212,7 +211,7 @@ class EmpiricalGroup(Group):
     def create_shared_params(self, trace=None, size=None, jitter=1, start=None):
         if trace is None:
             if size is None:
-                raise opvi.ParametrizationError("Need `trace` or `size` to initialize")
+                raise pymc.exceptions.ParametrizationError("Need `trace` or `size` to initialize")
             else:
                 start = self._prepare_start(start)
                 # Initialize particles

--- a/pymc/variational/operators.py
+++ b/pymc/variational/operators.py
@@ -19,9 +19,9 @@ from pytensor.graph.basic import Variable
 
 import pymc as pm
 
+from pymc.exceptions import NotImplementedInference, ParametrizationError
 from pymc.variational import opvi
 from pymc.variational.opvi import (
-    NotImplementedInference,
     ObjectiveFunction,
     Operator,
     _known_scan_ignored_inputs,
@@ -81,7 +81,7 @@ class KSDObjective(ObjectiveFunction):
 
     def __init__(self, op: KSD, tf: opvi.TestFunction):
         if not isinstance(op, KSD):
-            raise opvi.ParametrizationError("Op should be KSD")
+            raise ParametrizationError("Op should be KSD")
         super().__init__(op, tf)
 
     @pytensor.config.change_flags(compute_test_value="off")

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -68,6 +68,12 @@ from pymc.backends import to_inference_data
 from pymc.backends.base import MultiTrace
 from pymc.backends.ndarray import NDArray
 from pymc.blocking import DictToArrayBijection
+from pymc.exceptions import (
+    ExplicitInferenceError,
+    GroupError,
+    ParametrizationError,
+    VariationalInferenceError,
+)
 from pymc.initial_point import make_initial_point_fn
 from pymc.model import modelcontext
 from pymc.pytensorf import (
@@ -89,30 +95,6 @@ from pymc.variational.updates import adagrad_window
 from pymc.vartypes import discrete_types
 
 __all__ = ["ObjectiveFunction", "Operator", "TestFunction", "Group", "Approximation"]
-
-
-class VariationalInferenceError(Exception):
-    """Exception for VI specific cases"""
-
-
-class NotImplementedInference(VariationalInferenceError, NotImplementedError):
-    """Marking non functional parts of code"""
-
-
-class ExplicitInferenceError(VariationalInferenceError, TypeError):
-    """Exception for bad explicit inference"""
-
-
-class AEVBInferenceError(VariationalInferenceError, TypeError):
-    """Exception for bad aevb inference"""
-
-
-class ParametrizationError(VariationalInferenceError, ValueError):
-    """Error raised in case of bad parametrization"""
-
-
-class GroupError(VariationalInferenceError, TypeError):
-    """Error related to VI groups"""
 
 
 def _known_scan_ignored_inputs(terms):

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -64,6 +64,7 @@ from pytensor.tensor.shape import unbroadcast
 
 import pymc as pm
 
+from pymc.backends import to_inference_data
 from pymc.backends.base import MultiTrace
 from pymc.backends.ndarray import NDArray
 from pymc.blocking import DictToArrayBijection
@@ -1578,7 +1579,7 @@ class Approximation(WithMemoization):
         if not return_inferencedata:
             return multi_trace
         else:
-            return pm.to_inference_data(multi_trace, model=self.model, **kwargs)
+            return to_inference_data(multi_trace, model=self.model, **kwargs)
 
     @property
     def ndim(self):

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -29,8 +29,8 @@ import pymc as pm
 
 from pymc.distributions.continuous import Normal, Uniform, get_tau_sigma, interpolated
 from pymc.distributions.dist_math import clipped_beta_rvs
+from pymc.exceptions import ParameterValueError
 from pymc.logprob.basic import icdf, logcdf, logp
-from pymc.logprob.utils import ParameterValueError
 from pymc.pytensorf import floatX
 from pymc.testing import (
     BaseTestDistributionRandom,

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -29,8 +29,8 @@ from pytensor.tensor import TensorVariable
 import pymc as pm
 
 from pymc.distributions.discrete import Geometric, _OrderedLogistic, _OrderedProbit
+from pymc.exceptions import ParameterValueError
 from pymc.logprob.basic import icdf, logcdf, logp
-from pymc.logprob.utils import ParameterValueError
 from pymc.pytensorf import floatX
 from pymc.testing import (
     BaseTestDistributionRandom,

--- a/tests/distributions/test_dist_math.py
+++ b/tests/distributions/test_dist_math.py
@@ -33,7 +33,7 @@ from pymc.distributions.dist_math import (
     incomplete_beta,
     multigammaln,
 )
-from pymc.logprob.utils import ParameterValueError
+from pymc.exceptions import ParameterValueError
 from pymc.pytensorf import floatX
 from tests.helpers import verify_grad
 

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -39,8 +39,8 @@ from pymc.distributions.multivariate import (
     quaddist_matrix,
 )
 from pymc.distributions.shape_utils import change_dist_size, to_tuple
+from pymc.exceptions import ParameterValueError
 from pymc.logprob.basic import logp
-from pymc.logprob.utils import ParameterValueError
 from pymc.math import kronecker
 from pymc.pytensorf import compile_pymc, floatX, intX
 from pymc.sampling.forward import draw

--- a/tests/distributions/test_shape_utils.py
+++ b/tests/distributions/test_shape_utils.py
@@ -27,7 +27,6 @@ from pytensor.tensor.shape import SpecifyShape
 
 import pymc as pm
 
-from pymc import ShapeError
 from pymc.distributions.shape_utils import (
     broadcast_dist_samples_shape,
     change_dist_size,
@@ -39,6 +38,7 @@ from pymc.distributions.shape_utils import (
     rv_size_is_none,
     to_tuple,
 )
+from pymc.exceptions import ShapeError
 from pymc.model import Model
 
 test_shapes = [

--- a/tests/distributions/test_truncated.py
+++ b/tests/distributions/test_truncated.py
@@ -24,11 +24,10 @@ from pymc.distributions.continuous import Exponential, Gamma, TruncatedNormalRV
 from pymc.distributions.shape_utils import change_dist_size
 from pymc.distributions.transforms import _default_transform
 from pymc.distributions.truncated import Truncated, TruncatedRV, _truncated
-from pymc.exceptions import TruncationError
+from pymc.exceptions import ParameterValueError, TruncationError
 from pymc.logprob.abstract import _icdf
 from pymc.logprob.basic import logcdf, logp
 from pymc.logprob.transforms import IntervalTransform
-from pymc.logprob.utils import ParameterValueError
 from pymc.testing import assert_moment_is_expected
 
 

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -49,6 +49,7 @@ from pytensor.scan import scan
 
 from pymc.distributions.continuous import Cauchy
 from pymc.distributions.transforms import _default_transform, log, logodds
+from pymc.exceptions import ParameterValueError
 from pymc.logprob.abstract import MeasurableVariable, _logprob
 from pymc.logprob.basic import conditional_logp, icdf, logcdf, logp
 from pymc.logprob.transforms import (
@@ -72,7 +73,6 @@ from pymc.logprob.transforms import (
     TransformValuesMapping,
     TransformValuesRewrite,
 )
-from pymc.logprob.utils import ParameterValueError
 from pymc.testing import Rplusbig, Vector, assert_no_rvs
 from tests.distributions.test_transform import check_jacobian_det
 

--- a/tests/logprob/test_utils.py
+++ b/tests/logprob/test_utils.py
@@ -47,10 +47,10 @@ from pytensor.tensor.random.basic import normal, uniform
 
 import pymc as pm
 
+from pymc.exceptions import ParameterValueError
 from pymc.logprob.abstract import MeasurableVariable
 from pymc.logprob.basic import logp, transformed_conditional_logp
 from pymc.logprob.utils import (
-    ParameterValueError,
     check_potential_measurability,
     dirac_delta,
     rvs_to_value_vars,

--- a/tests/sampling/test_parallel.py
+++ b/tests/sampling/test_parallel.py
@@ -27,6 +27,7 @@ from pytensor.compile.ops import as_op
 from pytensor.tensor.type import TensorType
 
 import pymc as pm
+import pymc.exceptions
 import pymc.sampling.parallel as ps
 
 from pymc.pytensorf import floatX
@@ -87,7 +88,9 @@ def test_remote_pipe_closed():
         pm.Normal("y", mu=_crash_remote_process(x, at_pid), shape=2)
 
         step = pm.Metropolis()
-        with pytest.raises(ps.ParallelSamplingError, match="Chain [0-9] failed with") as ex:
+        with pytest.raises(
+            pymc.exceptions.ParallelSamplingError, match="Chain [0-9] failed with"
+        ) as ex:
             pm.sample(step=step, mp_ctx="spawn", tune=2, draws=2, cores=2, chains=2)
 
 

--- a/tests/step_methods/hmc/test_quadpotential.py
+++ b/tests/step_methods/hmc/test_quadpotential.py
@@ -20,13 +20,14 @@ import scipy.sparse
 
 import pymc
 
+from pymc.exceptions import PositiveDefiniteError
 from pymc.pytensorf import floatX
 from pymc.step_methods.hmc import quadpotential
 
 
 def test_elemwise_posdef():
     scaling = np.array([0, 2, 3])
-    with pytest.raises(quadpotential.PositiveDefiniteError):
+    with pytest.raises(PositiveDefiniteError):
         quadpotential.quad_potential(scaling, True)
 
 

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -36,8 +36,7 @@ import pymc as pm
 from pymc.distributions.dist_math import check_parameters
 from pymc.distributions.distribution import SymbolicRandomVariable
 from pymc.distributions.transforms import Interval
-from pymc.exceptions import NotConstantValueError
-from pymc.logprob.utils import ParameterValueError
+from pymc.exceptions import NotConstantValueError, ParameterValueError
 from pymc.pytensorf import (
     _replace_vars_in_graphs,
     collect_default_updates,

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -24,11 +24,12 @@ import pytensor.tensor as pt
 import pytest
 
 import pymc as pm
+import pymc.exceptions
 import pymc.variational.opvi as opvi
 
+from pymc.exceptions import NotImplementedInference
 from pymc.pytensorf import intX
 from pymc.variational.inference import ADVI, ASVGD, SVGD, FullRankADVI
-from pymc.variational.opvi import NotImplementedInference
 from tests import models
 
 pytestmark = pytest.mark.usefixtures("strict_float32", "seeded_test", "fail_on_warning")
@@ -288,14 +289,14 @@ def test_replacements(binomial_model_inference):
     try:
         p_z = approx.sample_node(p_t, deterministic=True, size=10)
         assert p_z.shape.eval() == (10,)
-    except opvi.NotImplementedInference:
+    except pymc.exceptions.NotImplementedInference:
         pass
 
     try:
         p_d = approx.sample_node(p_t, deterministic=True)
         sampled = [pm.draw(p_d) for _ in range(100)]
         assert all(map(operator.eq, sampled[1:], sampled[:-1]))  # deterministic
-    except opvi.NotImplementedInference:
+    except pymc.exceptions.NotImplementedInference:
         pass
 
     p_r = approx.sample_node(p_t, deterministic=d)

--- a/tests/variational/test_opvi.py
+++ b/tests/variational/test_opvi.py
@@ -19,6 +19,7 @@ import pytensor.tensor as pt
 import pytest
 
 import pymc as pm
+import pymc.exceptions
 
 from pymc.variational import opvi
 from pymc.variational.approximations import (
@@ -41,7 +42,7 @@ def test_discrete_not_allowed():
         mu = pm.Normal("mu", mu=0, sigma=10, size=3)
         z = pm.Categorical("z", p=pt.ones(3) / 3, size=len(y))
         pm.Normal("y_obs", mu=mu[z], sigma=1.0, observed=y)
-        with pytest.raises(opvi.ParametrizationError, match="Discrete variables"):
+        with pytest.raises(pymc.exceptions.ParametrizationError, match="Discrete variables"):
             pm.fit(n=1)  # fails
 
 


### PR DESCRIPTION
I agree it's fairly silly, but just proof-of-concept to illustrate how easy it is.

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--4.org.readthedocs.build/en/4/

<!-- readthedocs-preview pymc end -->